### PR TITLE
Changes to Joomla manual examples to support lazy loading of plugins

### DIFF
--- a/plugin-example-shortcode/README.md
+++ b/plugin-example-shortcode/README.md
@@ -4,6 +4,8 @@ plg-shortcodes
 This is an example content plugin which serves as a 
 [plugin tutorial](https://manual.joomla.org/docs/building-extensions/plugins/basic-content-plugin/).
 
+It should be run on Joomla 6.1 or later. 
+
 It handles the events onContentPrepare and onContentAfterTitle, and:
 
 - replaces article shortcodes (in {} brackets) with field values (from the Joomla global configuration)

--- a/plugin-example-shortcode/plg_shortcodes/services/provider.php
+++ b/plugin-example-shortcode/plg_shortcodes/services/provider.php
@@ -12,19 +12,53 @@ use My\Plugin\Content\Shortcodes\Extension\Shortcode;
     {
         public function register(Container $container)
         {
-            $container->set(
-                PluginInterface::class,
-                function (Container $container) {
-    
-                    $config = (array) PluginHelper::getPlugin('content', 'shortcodes');
-                    $subject = $container->get(DispatcherInterface::class);
-                    $app = Factory::getApplication();
-                    
-                    $plugin = new Shortcode($subject, $config);
-                    $plugin->setApplication($app);
-    
-                    return $plugin;
-                }
-            );
+            if (version_compare(JVERSION, '6.1', '>=')) {
+                // Use lazy plugin class for performance 
+                // See https://github.com/joomla/joomla-cms/pull/45062
+                $container->set(
+                    PluginInterface::class,
+                    $container->lazy(Shortcode::class, function (Container $container) {
+        
+                        $config = (array) PluginHelper::getPlugin('content', 'shortcodes');
+                        $app = Factory::getApplication();
+                        
+                        $plugin = new Shortcode($config);
+                        $plugin->setApplication($app);
+        
+                        return $plugin;
+                    })
+                );
+            } else if (version_compare(JVERSION, '5.3', '>=')) {
+                // Dispatcher passed to plugin constructor deprecated 
+                // See https://github.com/joomla/joomla-cms/pull/43430
+                $container->set(
+                    PluginInterface::class,
+                    function (Container $container) {
+        
+                        $config = (array) PluginHelper::getPlugin('content', 'shortcodes');
+                        $app = Factory::getApplication();
+                        
+                        $plugin = new Shortcode($config);
+                        $plugin->setApplication($app);
+        
+                        return $plugin;
+                    }
+                );
+            } else {
+                $container->set(
+                    PluginInterface::class,
+                    function (Container $container) {
+        
+                        $config = (array) PluginHelper::getPlugin('content', 'shortcodes');
+                        $dispatcher = $container->get(DispatcherInterface::class);
+                        $app = Factory::getApplication();
+                        
+                        $plugin = new Shortcode($dispatcher, $config);
+                        $plugin->setApplication($app);
+        
+                        return $plugin;
+                    }
+                );
+            }
         }
     };

--- a/plugin-example-shortcode/plg_shortcodes/services/provider.php
+++ b/plugin-example-shortcode/plg_shortcodes/services/provider.php
@@ -12,53 +12,18 @@ use My\Plugin\Content\Shortcodes\Extension\Shortcode;
     {
         public function register(Container $container)
         {
-            if (version_compare(JVERSION, '6.1', '>=')) {
-                // Use lazy plugin class for performance 
-                // See https://github.com/joomla/joomla-cms/pull/45062
-                $container->set(
-                    PluginInterface::class,
-                    $container->lazy(Shortcode::class, function (Container $container) {
-        
-                        $config = (array) PluginHelper::getPlugin('content', 'shortcodes');
-                        $app = Factory::getApplication();
-                        
-                        $plugin = new Shortcode($config);
-                        $plugin->setApplication($app);
-        
-                        return $plugin;
-                    })
-                );
-            } else if (version_compare(JVERSION, '5.3', '>=')) {
-                // Dispatcher passed to plugin constructor deprecated 
-                // See https://github.com/joomla/joomla-cms/pull/43430
-                $container->set(
-                    PluginInterface::class,
-                    function (Container $container) {
-        
-                        $config = (array) PluginHelper::getPlugin('content', 'shortcodes');
-                        $app = Factory::getApplication();
-                        
-                        $plugin = new Shortcode($config);
-                        $plugin->setApplication($app);
-        
-                        return $plugin;
-                    }
-                );
-            } else {
-                $container->set(
-                    PluginInterface::class,
-                    function (Container $container) {
-        
-                        $config = (array) PluginHelper::getPlugin('content', 'shortcodes');
-                        $dispatcher = $container->get(DispatcherInterface::class);
-                        $app = Factory::getApplication();
-                        
-                        $plugin = new Shortcode($dispatcher, $config);
-                        $plugin->setApplication($app);
-        
-                        return $plugin;
-                    }
-                );
-            }
+            $container->set(
+                PluginInterface::class,
+                $container->lazy(Shortcode::class, function (Container $container) {
+    
+                    $config = (array) PluginHelper::getPlugin('content', 'shortcodes');
+                    $app = Factory::getApplication();
+                    
+                    $plugin = new Shortcode($config);
+                    $plugin->setApplication($app);
+    
+                    return $plugin;
+                })
+            );
         }
     };


### PR DESCRIPTION
I'm starting to document more fully the lazy plugin aspect.

This leads us into having different code for different versions of Joomla, and we need to agree in general how to document this within the Joomla manual examples repository.

I believe that any code in the manual examples repo should work for all the versions which are maintained in the Joomla manual, so at the moment that would be 4.4, 5.4, 6.0 and 6.1.

I've been thinking about the best way to handle these version-specific code sections and have proposed this PR, which is now up for review.

While the code in the manual examples repository needs to have the switch on JVERSION, I would propose NOT having this in the manual - so in the manual the particular document version would just have the code appropriate to that Joomla version. 

For example at https://manual.joomla.org/docs/building-extensions/plugins/basic-content-plugin/ it would just show the services/provider.php file for that version alone. 

I've also put comments for each version change which have links to the Joomla code changes. I'm not sure that everyone will want to look at these, but there are probably some people who will, and having this makes it easy for them. 

Instead of having the version if/then statement at the `$container->set()` level we could have it inside the `set()` to show finer granularity on the differences between 4.4 and 5.3 - eg

```
function (Container $container) {
    $config = (array) PluginHelper::getPlugin('content', 'shortcodes');
    $app = Factory::getApplication();

    if (version_compare(JVERSION, '5.3', '>=')) {

        // Dispatcher passed to plugin constructor deprecated 
        // See https://github.com/joomla/joomla-cms/pull/43430
        $plugin = new Shortcode($config);

    } else {

        $dispatcher = $container->get(DispatcherInterface::class);
        $plugin = new Shortcode($dispatcher, $config);

    }

    $plugin->setApplication($app);
    return $plugin;
}
```

I think that might be clearer - but let me know what you think. 