### PR TITLE
JPATH_PLATFORM replaced by JEXEC

### DIFF
--- a/component-exampleform/com_exampleform/components/com_exampleform/src/Field/MytimeField.php
+++ b/component-exampleform/com_exampleform/components/com_exampleform/src/Field/MytimeField.php
@@ -1,7 +1,7 @@
 <?php
 namespace My\Component\Exampleform\Site\Field;
 
-defined('JPATH_PLATFORM') or die;
+defined('_JEXEC') or die;
 
 use Joomla\CMS\Form\FormField;
 


### PR DESCRIPTION
For some reason

     defined('JPATH_PLATFORM ') or die; 

was in a source file.